### PR TITLE
Added node_options parameter to constructor with default value

### DIFF
--- a/mocap_control/mocap_control/include/mocap_control/ControlledLifecycleNode.hpp
+++ b/mocap_control/mocap_control/include/mocap_control/ControlledLifecycleNode.hpp
@@ -29,8 +29,9 @@ namespace mocap_control
 class ControlledLifecycleNode : public rclcpp_lifecycle::LifecycleNode
 {
 public:
-  explicit ControlledLifecycleNode(const std::string & system_id, 
-              const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions());
+  explicit ControlledLifecycleNode(
+    const std::string & system_id,
+    const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions());
 
 protected:
   template<typename MessageT, typename AllocatorT = std::allocator<void>>

--- a/mocap_control/mocap_control/include/mocap_control/ControlledLifecycleNode.hpp
+++ b/mocap_control/mocap_control/include/mocap_control/ControlledLifecycleNode.hpp
@@ -29,7 +29,8 @@ namespace mocap_control
 class ControlledLifecycleNode : public rclcpp_lifecycle::LifecycleNode
 {
 public:
-  explicit ControlledLifecycleNode(const std::string & system_id, const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions());
+  explicit ControlledLifecycleNode(const std::string & system_id, 
+              const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions());
 
 protected:
   template<typename MessageT, typename AllocatorT = std::allocator<void>>

--- a/mocap_control/mocap_control/include/mocap_control/ControlledLifecycleNode.hpp
+++ b/mocap_control/mocap_control/include/mocap_control/ControlledLifecycleNode.hpp
@@ -29,7 +29,7 @@ namespace mocap_control
 class ControlledLifecycleNode : public rclcpp_lifecycle::LifecycleNode
 {
 public:
-  explicit ControlledLifecycleNode(const std::string & system_id);
+  explicit ControlledLifecycleNode(const std::string & system_id, const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions());
 
 protected:
   template<typename MessageT, typename AllocatorT = std::allocator<void>>

--- a/mocap_control/mocap_control/src/mocap_control/ControlledLifecycleNode.cpp
+++ b/mocap_control/mocap_control/src/mocap_control/ControlledLifecycleNode.cpp
@@ -29,8 +29,9 @@ namespace mocap_control
 
 using std::placeholders::_1;
 
-ControlledLifecycleNode::ControlledLifecycleNode(const std::string & system_id, 
-                          const rclcpp::NodeOptions & node_options)
+ControlledLifecycleNode::ControlledLifecycleNode(
+  const std::string & system_id,
+  const rclcpp::NodeOptions & node_options)
 : LifecycleNode(system_id, node_options)
 {
   mocap_control_sub_ = create_subscription<mocap_control_msgs::msg::Control>(

--- a/mocap_control/mocap_control/src/mocap_control/ControlledLifecycleNode.cpp
+++ b/mocap_control/mocap_control/src/mocap_control/ControlledLifecycleNode.cpp
@@ -29,8 +29,8 @@ namespace mocap_control
 
 using std::placeholders::_1;
 
-ControlledLifecycleNode::ControlledLifecycleNode(const std::string & system_id)
-: LifecycleNode(system_id)
+ControlledLifecycleNode::ControlledLifecycleNode(const std::string & system_id, const rclcpp::NodeOptions & node_options)
+: LifecycleNode(system_id, node_options)
 {
   mocap_control_sub_ = create_subscription<mocap_control_msgs::msg::Control>(
     "mocap_control", rclcpp::QoS(100).reliable(),

--- a/mocap_control/mocap_control/src/mocap_control/ControlledLifecycleNode.cpp
+++ b/mocap_control/mocap_control/src/mocap_control/ControlledLifecycleNode.cpp
@@ -29,7 +29,8 @@ namespace mocap_control
 
 using std::placeholders::_1;
 
-ControlledLifecycleNode::ControlledLifecycleNode(const std::string & system_id, const rclcpp::NodeOptions & node_options)
+ControlledLifecycleNode::ControlledLifecycleNode(const std::string & system_id, 
+                          const rclcpp::NodeOptions & node_options)
 : LifecycleNode(system_id, node_options)
 {
   mocap_control_sub_ = create_subscription<mocap_control_msgs::msg::Control>(


### PR DESCRIPTION
In order to prevent multiple inheritance, mocap4ros2 vicon driver uses this parameter on its constructor.