### PR TITLE
Fix broken dependency in gt_domponents.cpp line 18

### DIFF
--- a/mocap_robot_gt/mocap_robot_gt/src/mocap_robot_gt/gt_component.cpp
+++ b/mocap_robot_gt/mocap_robot_gt/src/mocap_robot_gt/gt_component.cpp
@@ -15,7 +15,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/static_transform_broadcaster.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <vector>
 


### PR DESCRIPTION
When trying to build the `mocap_robot_gt` package with `colcon build` on Ubuntu 20.04 using ROS 2 Foxy, I received the following error message:

```
--- stderr: mocap_robot_gt                                                                                                                
/home/dave/optitrack_ws/src/optitrack/mocap/mocap_robot_gt/mocap_robot_gt/src/mocap_robot_gt/gt_component.cpp:18:10: fatal error: tf2_geometry_msgs/tf2_geometry_msgs.hpp: No such file or directory
   18 | #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/gt_component.dir/build.make:63: CMakeFiles/gt_component.dir/src/mocap_robot_gt/gt_component.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:84: CMakeFiles/gt_component.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:141: all] Error 2
---
Failed   <<< mocap_robot_gt [7.62s, exited with code 2]
```

As a result, I investigated the issue and found that the file in `/opt/ros/foxy/include/tf2_geometry_msgs` is called `tf2_geometry_msgs.h`. The file extension is `.h` and no `.hpp`.

Therefore, I make this pull request. I am not sure if this is a change from the `tf2_geometry_msgs`. I do not know if this file is having the same file extension on ROS 2 Humble, this needs to be checked.