### PR TITLE
added use_header option

### DIFF
--- a/mocap4r2_marker_viz/mocap4r2_marker_viz/include/mocap4r2_marker_viz/mocap4r2_marker_viz_node.hpp
+++ b/mocap4r2_marker_viz/mocap4r2_marker_viz/include/mocap4r2_marker_viz/mocap4r2_marker_viz_node.hpp
@@ -52,10 +52,10 @@ private:
   void rb_callback(const mocap4r2_msgs::msg::RigidBodies::SharedPtr msg) const;
 
   visualization_msgs::msg::Marker marker2visual(
-    int index, const geometry_msgs::msg::Point & translation) const;
+    int index, const geometry_msgs::msg::Point & translation, const std_msgs::msg::Header & header) const;
 
   visualization_msgs::msg::Marker rb2visual(
-    int index, const geometry_msgs::msg::Pose & poserb) const;
+    int index, const geometry_msgs::msg::Pose & poserb, const std_msgs::msg::Header & header) const;
 
   geometry_msgs::msg::Pose mocap2rviz(const geometry_msgs::msg::Pose mocap4r2_pose) const;
 
@@ -67,6 +67,7 @@ private:
 
   geometry_msgs::msg::Vector3 marker_scale_;
   float marker_lifetime_;
+  bool use_header_;
   std::string marker_frame_;
   std::string namespace_;
   std::string mocap4r2_system_;

--- a/mocap4r2_marker_viz/mocap4r2_marker_viz/include/mocap4r2_marker_viz/mocap4r2_marker_viz_node.hpp
+++ b/mocap4r2_marker_viz/mocap4r2_marker_viz/include/mocap4r2_marker_viz/mocap4r2_marker_viz_node.hpp
@@ -52,11 +52,11 @@ private:
   void rb_callback(const mocap4r2_msgs::msg::RigidBodies::SharedPtr msg) const;
 
   visualization_msgs::msg::Marker marker2visual(
-    int index, const geometry_msgs::msg::Point & translation, 
+    int index, const geometry_msgs::msg::Point & translation,
     const std_msgs::msg::Header & header) const;
 
   visualization_msgs::msg::Marker rb2visual(
-    int index, const geometry_msgs::msg::Pose & poserb, 
+    int index, const geometry_msgs::msg::Pose & poserb,
     const std_msgs::msg::Header & header) const;
 
   geometry_msgs::msg::Pose mocap2rviz(const geometry_msgs::msg::Pose mocap4r2_pose) const;

--- a/mocap4r2_marker_viz/mocap4r2_marker_viz/include/mocap4r2_marker_viz/mocap4r2_marker_viz_node.hpp
+++ b/mocap4r2_marker_viz/mocap4r2_marker_viz/include/mocap4r2_marker_viz/mocap4r2_marker_viz_node.hpp
@@ -52,10 +52,12 @@ private:
   void rb_callback(const mocap4r2_msgs::msg::RigidBodies::SharedPtr msg) const;
 
   visualization_msgs::msg::Marker marker2visual(
-    int index, const geometry_msgs::msg::Point & translation, const std_msgs::msg::Header & header) const;
+    int index, const geometry_msgs::msg::Point & translation, 
+    const std_msgs::msg::Header & header) const;
 
   visualization_msgs::msg::Marker rb2visual(
-    int index, const geometry_msgs::msg::Pose & poserb, const std_msgs::msg::Header & header) const;
+    int index, const geometry_msgs::msg::Pose & poserb, 
+    const std_msgs::msg::Header & header) const;
 
   geometry_msgs::msg::Pose mocap2rviz(const geometry_msgs::msg::Pose mocap4r2_pose) const;
 
@@ -67,8 +69,6 @@ private:
 
   geometry_msgs::msg::Vector3 marker_scale_;
   float marker_lifetime_;
-  bool use_header_;
-  std::string marker_frame_;
   std::string namespace_;
   std::string mocap4r2_system_;
   std_msgs::msg::ColorRGBA default_marker_color_;

--- a/mocap4r2_marker_viz/mocap4r2_marker_viz/src/mocap4r2_marker_viz_node.cpp
+++ b/mocap4r2_marker_viz/mocap4r2_marker_viz/src/mocap4r2_marker_viz_node.cpp
@@ -143,7 +143,7 @@ MarkerVisualizer::rb_callback(const mocap4r2_msgs::msg::RigidBodies::SharedPtr m
     visual_markers_rb.markers.push_back(rb2visual(counter_rb++, rb.pose, msg->header));
 
     for (const mocap4r2_msgs::msg::Marker & marker : rb.markers) {
-      visual_markers_rb.markers.push_back(marker2visual(counter_markers_rb++, 
+      visual_markers_rb.markers.push_back(marker2visual(counter_markers_rb++,
                                                         marker.translation, msg->header));
     }
   }
@@ -153,7 +153,7 @@ MarkerVisualizer::rb_callback(const mocap4r2_msgs::msg::RigidBodies::SharedPtr m
 
 
 visualization_msgs::msg::Marker
-MarkerVisualizer::rb2visual(int index, const geometry_msgs::msg::Pose & poserb,  
+MarkerVisualizer::rb2visual(int index, const geometry_msgs::msg::Pose & poserb,
                             const std_msgs::msg::Header  & header) const
 {
   visualization_msgs::msg::Marker viz_marker;

--- a/mocap4r2_marker_viz/mocap4r2_marker_viz/src/mocap4r2_marker_viz_node.cpp
+++ b/mocap4r2_marker_viz/mocap4r2_marker_viz/src/mocap4r2_marker_viz_node.cpp
@@ -36,6 +36,7 @@ MarkerVisualizer::MarkerVisualizer()
   declare_parameter<double>("marker_scale_y", 0.014f);
   declare_parameter<double>("marker_scale_z", 0.014f);
   declare_parameter<float>("marker_lifetime", 0.01f);
+  declare_parameter<bool>("use_header", false);
   declare_parameter<std::string>("marker_frame", "map");
   declare_parameter<std::string>("namespace", "mocap4r2_markers");
   declare_parameter<std::string>("mocap4r2_system", "optitrack");
@@ -47,7 +48,8 @@ MarkerVisualizer::MarkerVisualizer()
   get_parameter<double>("marker_scale_x", marker_scale_.x);
   get_parameter<double>("marker_scale_y", marker_scale_.y);
   get_parameter<double>("marker_scale_z", marker_scale_.z);
-  get_parameter<float>("marker_lifetime", marker_lifetime_);
+  get_parameter<bool>("use_header", use_header_);
+  get_parameter<std::string>("marker_frame", marker_frame_);
   get_parameter<std::string>("marker_frame", marker_frame_);
   get_parameter<std::string>("namespace", namespace_);
   get_parameter<std::string>("mocap4r2_system", mocap4r2_system_);
@@ -100,17 +102,21 @@ MarkerVisualizer::marker_callback(const mocap4r2_msgs::msg::Markers::SharedPtr m
   static int counter = 0;
   visualization_msgs::msg::MarkerArray visual_markers;
   for (const mocap4r2_msgs::msg::Marker & marker : msg->markers) {
-    visual_markers.markers.push_back(marker2visual(counter++, marker.translation));
+    visual_markers.markers.push_back(marker2visual(counter++, marker.translation, msg->header));
   }
   publisher_->publish(visual_markers);
 }
 
 visualization_msgs::msg::Marker
-MarkerVisualizer::marker2visual(int index, const geometry_msgs::msg::Point & translation) const
+MarkerVisualizer::marker2visual(int index, const geometry_msgs::msg::Point & translation, const std_msgs::msg::Header  & header) const
 {
   visualization_msgs::msg::Marker viz_marker;
-  viz_marker.header.frame_id = marker_frame_;
-  viz_marker.header.stamp = rclcpp::Clock().now();
+  if (use_header_){
+    viz_marker.header = header;
+  } else {
+    viz_marker.header.frame_id = marker_frame_;
+    viz_marker.header.stamp = rclcpp::Clock().now();
+  }
   viz_marker.ns = namespace_;
   viz_marker.color = default_marker_color_;
   viz_marker.id = index;
@@ -142,10 +148,10 @@ MarkerVisualizer::rb_callback(const mocap4r2_msgs::msg::RigidBodies::SharedPtr m
   visualization_msgs::msg::MarkerArray visual_markers_rb;
 
   for (const mocap4r2_msgs::msg::RigidBody & rb : msg->rigidbodies) {
-    visual_markers_rb.markers.push_back(rb2visual(counter_rb++, rb.pose));
+    visual_markers_rb.markers.push_back(rb2visual(counter_rb++, rb.pose, msg->header));
 
     for (const mocap4r2_msgs::msg::Marker & marker : rb.markers) {
-      visual_markers_rb.markers.push_back(marker2visual(counter_markers_rb++, marker.translation));
+      visual_markers_rb.markers.push_back(marker2visual(counter_markers_rb++, marker.translation, msg->header));
     }
   }
 
@@ -154,11 +160,15 @@ MarkerVisualizer::rb_callback(const mocap4r2_msgs::msg::RigidBodies::SharedPtr m
 
 
 visualization_msgs::msg::Marker
-MarkerVisualizer::rb2visual(int index, const geometry_msgs::msg::Pose & poserb) const
+MarkerVisualizer::rb2visual(int index, const geometry_msgs::msg::Pose & poserb,  const std_msgs::msg::Header  & header) const
 {
   visualization_msgs::msg::Marker viz_marker;
-  viz_marker.header.frame_id = marker_frame_;
-  viz_marker.header.stamp = rclcpp::Clock().now();
+  if (use_header_){
+    viz_marker.header = header;
+  } else {
+    viz_marker.header.frame_id = marker_frame_;
+    viz_marker.header.stamp = rclcpp::Clock().now();
+  }  
   viz_marker.ns = namespace_;
   viz_marker.color = default_marker_color_;
   viz_marker.id = index;


### PR DESCRIPTION
Hi,
I'm back using your great code, and I noticed that when playing back a rosbag I could not see the markers from the mocap system. Seems that my recorded tf was too old to be used with markers' headers, which had Clock:now timestamp.
I tried adding "use sim_time" to the mocap system, but didn't work.
So I thought that in any case, when creating rviz markers from the mocap markers, perhaps it would be a good idea to "forward" original timestamps, and created this pull request.

What do you think?
Cheers