### PR TITLE
Add option for publishing tf

### DIFF
--- a/mocap4r2_marker_viz/mocap4r2_marker_viz/CMakeLists.txt
+++ b/mocap4r2_marker_viz/mocap4r2_marker_viz/CMakeLists.txt
@@ -24,6 +24,8 @@ find_package(mocap4r2_marker_viz_srvs REQUIRED)
 find_package(mocap4r2_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 add_executable(mocap4r2_marker_viz src/mocap4r2_marker_viz_main.cpp)
 
@@ -34,7 +36,7 @@ target_include_directories(${PROJECT_NAME}_NODE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-ament_target_dependencies(${PROJECT_NAME}_NODE rclcpp mocap4r2_msgs visualization_msgs geometry_msgs mocap4r2_marker_viz_srvs)
+ament_target_dependencies(${PROJECT_NAME}_NODE rclcpp tf2_geometry_msgs tf2_ros mocap4r2_msgs visualization_msgs geometry_msgs mocap4r2_marker_viz_srvs)
 
 target_link_libraries(mocap4r2_marker_viz ${PROJECT_NAME}_NODE)
 

--- a/mocap4r2_marker_viz/mocap4r2_marker_viz/include/mocap4r2_marker_viz/mocap4r2_marker_viz_node.hpp
+++ b/mocap4r2_marker_viz/mocap4r2_marker_viz/include/mocap4r2_marker_viz/mocap4r2_marker_viz_node.hpp
@@ -34,6 +34,7 @@
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "mocap4r2_marker_viz_srvs/srv/set_marker_color.hpp"
 #include "mocap4r2_marker_viz_srvs/srv/reset_marker_color.hpp"
+#include "tf2_ros/transform_broadcaster.h"
 
 typedef mocap4r2_marker_viz_srvs::srv::SetMarkerColor SetMarkerColor;
 typedef mocap4r2_marker_viz_srvs::srv::ResetMarkerColor ResetMarkerColor;
@@ -67,10 +68,13 @@ private:
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr publisher_rb_;
   rclcpp::Subscription<mocap4r2_msgs::msg::RigidBodies>::SharedPtr markers_subscription_rb_;
 
+  std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+
   geometry_msgs::msg::Vector3 marker_scale_;
   float marker_lifetime_;
   std::string namespace_;
   std::string mocap4r2_system_;
+  bool publish_tf_;
   std_msgs::msg::ColorRGBA default_marker_color_;
   std::map<int, std_msgs::msg::ColorRGBA> marker_color_;
 };

--- a/mocap4r2_marker_viz/mocap4r2_marker_viz/launch/mocap4r2_marker_viz.launch.py
+++ b/mocap4r2_marker_viz/mocap4r2_marker_viz/launch/mocap4r2_marker_viz.launch.py
@@ -28,10 +28,16 @@ def generate_launch_description():
     rviz_config_file = LaunchConfiguration('rviz_config_file')
     use_namespace = LaunchConfiguration('use_namespace')
     mocap4r2_system = LaunchConfiguration('mocap4r2_system')
+    publish_tf = LaunchConfiguration('publish_tf')
 
     declare_mocap4r2_system = DeclareLaunchArgument(
         'mocap4r2_system',
         default_value='optitrack',
+        description='')
+
+    declare_publish_tf = DeclareLaunchArgument(
+        'publish_tf',
+        default_value='false',
         description='')
 
     declare_rviz_config_file_cmd = DeclareLaunchArgument(
@@ -62,7 +68,8 @@ def generate_launch_description():
         executable='mocap4r2_marker_viz',
         output='both',
         emulate_tty=True,
-        parameters=[{'mocap4r2_system': mocap4r2_system}],
+        parameters=[{'mocap4r2_system': mocap4r2_system},
+                    {'publish_tf': publish_tf}],
     )
 
     # Create the launch description and populate
@@ -74,6 +81,7 @@ def generate_launch_description():
     ld.add_action(declare_rviz_config_file_cmd)
     ld.add_action(declare_use_namespace_cmd)
     ld.add_action(declare_mocap4r2_system)
+    ld.add_action(declare_publish_tf)
     ld.add_action(declare_use_rviz_cmd)
 
     ld.add_action(start_rviz_cmd)

--- a/mocap4r2_marker_viz/mocap4r2_marker_viz/package.xml
+++ b/mocap4r2_marker_viz/mocap4r2_marker_viz/package.xml
@@ -13,6 +13,8 @@
   <depend>visualization_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>mocap4r2_marker_viz_srvs</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/mocap4r2_marker_viz/mocap4r2_marker_viz/src/mocap4r2_marker_viz_node.cpp
+++ b/mocap4r2_marker_viz/mocap4r2_marker_viz/src/mocap4r2_marker_viz_node.cpp
@@ -16,6 +16,10 @@
 // Author: Jose Miguel Guerrero Hernandez <josemiguel.guerrero@urjc.es>
 
 #include <string>
+#include <vector>
+
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "mocap4r2_marker_viz/mocap4r2_marker_viz_node.hpp"
 
@@ -38,6 +42,7 @@ MarkerVisualizer::MarkerVisualizer()
   declare_parameter<float>("marker_lifetime", 0.01f);
   declare_parameter<std::string>("namespace", "mocap4r2_markers");
   declare_parameter<std::string>("mocap4r2_system", "optitrack");
+  declare_parameter<bool>("publish_tf", false);
 
   get_parameter<float>("default_marker_color_r", default_marker_color_.r);
   get_parameter<float>("default_marker_color_g", default_marker_color_.g);
@@ -49,6 +54,7 @@ MarkerVisualizer::MarkerVisualizer()
   get_parameter<float>("marker_lifetime", marker_lifetime_);
   get_parameter<std::string>("namespace", namespace_);
   get_parameter<std::string>("mocap4r2_system", mocap4r2_system_);
+  get_parameter<bool>("publish_tf", publish_tf_);
 
   markers_subscription_ = this->create_subscription<mocap4r2_msgs::msg::Markers>(
     "markers", 1000, std::bind(&MarkerVisualizer::marker_callback, this, _1));
@@ -59,6 +65,9 @@ MarkerVisualizer::MarkerVisualizer()
 
   publisher_rb_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
     "visualization_marker_rb", 1000);
+
+  tf_broadcaster_ =
+      std::make_unique<tf2_ros::TransformBroadcaster>(*this);
 }
 
 
@@ -132,6 +141,23 @@ MarkerVisualizer::marker2visual(
 void
 MarkerVisualizer::rb_callback(const mocap4r2_msgs::msg::RigidBodies::SharedPtr msg) const
 {
+  if (publish_tf_) {
+    std::vector<geometry_msgs::msg::TransformStamped> transforms {};
+    for (const mocap4r2_msgs::msg::RigidBody & rb : msg->rigidbodies) {
+      auto const pose = mocap2rviz(rb.pose);
+      geometry_msgs::msg::TransformStamped transform_stamped {};
+      transform_stamped.header = msg->header;
+
+      tf2::Transform transform {};
+      tf2::fromMsg(pose, transform);
+      tf2::toMsg(transform, transform_stamped.transform);
+
+      transform_stamped.child_frame_id = rb.rigid_body_name;
+      transforms.push_back(transform_stamped);
+    }
+    tf_broadcaster_->sendTransform(transforms);
+  }
+
   if (publisher_rb_->get_subscription_count() == 0) {
     return;
   }


### PR DESCRIPTION
This pull requests adds the option `publish_tf` to the `mocap4r2_marker_viz` package to publish the coordinate frames of rigid bodies to `/tf`. This is useful for working on evaluation of odometry and SLAM with e.g. [evo](https://github.com/MichaelGrupp/evo/wiki/Formats#bag--bag2---ros1ros2-bagfile).